### PR TITLE
Logs as a top level node

### DIFF
--- a/openapi/spec.json
+++ b/openapi/spec.json
@@ -6619,7 +6619,7 @@
       "post": {
         "operationId": "postProjectLogsIdInsert",
         "tags": [
-          "Projects"
+          "Logs"
         ],
         "description": "Insert a set of events into the project logs",
         "summary": "Insert project logs events",
@@ -6800,7 +6800,7 @@
       "post": {
         "operationId": "postProjectLogsIdFetch",
         "tags": [
-          "Projects"
+          "Logs"
         ],
         "description": "Fetch the events in a project logs. Equivalent to the GET form of the same path, but with the parameters in the request body rather than in the URL query",
         "summary": "Fetch project logs (POST form)",
@@ -6917,7 +6917,7 @@
       "get": {
         "operationId": "getProjectLogsIdFetch",
         "tags": [
-          "Projects"
+          "Logs"
         ],
         "description": "Fetch the events in a project logs. Equivalent to the POST form of the same path, but with the parameters in the URL query rather than in the request body",
         "summary": "Fetch project logs (GET form)",
@@ -7099,7 +7099,7 @@
       "post": {
         "operationId": "postProjectLogsIdFeedback",
         "tags": [
-          "Projects"
+          "Logs"
         ],
         "description": "Log feedback for a set of project logs events",
         "summary": "Feedback for project logs events",

--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -5694,7 +5694,7 @@ paths:
     post:
       operationId: postProjectLogsIdInsert
       tags:
-        - Projects
+        - Logs
       description: Insert a set of events into the project logs
       summary: Insert project logs events
       security:
@@ -5806,7 +5806,7 @@ paths:
     post:
       operationId: postProjectLogsIdFetch
       tags:
-        - Projects
+        - Logs
       description: Fetch the events in a project logs. Equivalent to the GET form of
         the same path, but with the parameters in the request body rather than
         in the URL query
@@ -5880,7 +5880,7 @@ paths:
     get:
       operationId: getProjectLogsIdFetch
       tags:
-        - Projects
+        - Logs
       description: Fetch the events in a project logs. Equivalent to the POST form of
         the same path, but with the parameters in the URL query rather than in
         the request body
@@ -5991,7 +5991,7 @@ paths:
     post:
       operationId: postProjectLogsIdFeedback
       tags:
-        - Projects
+        - Logs
       description: Log feedback for a set of project logs events
       summary: Feedback for project logs events
       security:


### PR DESCRIPTION
We want Logs as a top-level node in the docs. 

Aligns with: https://github.com/braintrustdata/braintrust/pull/2415