### PR TITLE
Update openapi spec to allow monitor-scopoed views

### DIFF
--- a/openapi/spec.json
+++ b/openapi/spec.json
@@ -6614,45 +6614,6 @@
           {
             "type": "object",
             "properties": {
-              "columnVisibility": {
-                "type": "object",
-                "nullable": true,
-                "additionalProperties": {
-                  "type": "boolean"
-                }
-              },
-              "columnOrder": {
-                "type": "array",
-                "nullable": true,
-                "items": {
-                  "type": "string"
-                }
-              },
-              "columnSizing": {
-                "type": "object",
-                "nullable": true,
-                "additionalProperties": {
-                  "type": "number"
-                }
-              },
-              "grouping": {
-                "type": "string",
-                "nullable": true
-              },
-              "rowHeight": {
-                "type": "string",
-                "nullable": true
-              },
-              "layout": {
-                "type": "string",
-                "nullable": true
-              }
-            },
-            "title": "TableViewOptions"
-          },
-          {
-            "type": "object",
-            "properties": {
               "viewType": {
                 "type": "string",
                 "enum": [
@@ -6711,6 +6672,45 @@
               "options"
             ],
             "title": "MonitorViewOptions"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "columnVisibility": {
+                "type": "object",
+                "nullable": true,
+                "additionalProperties": {
+                  "type": "boolean"
+                }
+              },
+              "columnOrder": {
+                "type": "array",
+                "nullable": true,
+                "items": {
+                  "type": "string"
+                }
+              },
+              "columnSizing": {
+                "type": "object",
+                "nullable": true,
+                "additionalProperties": {
+                  "type": "number"
+                }
+              },
+              "grouping": {
+                "type": "string",
+                "nullable": true
+              },
+              "rowHeight": {
+                "type": "string",
+                "nullable": true
+              },
+              "layout": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            "title": "TableViewOptions"
           },
           {
             "type": "null"

--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -5671,33 +5671,6 @@ components:
       anyOf:
         - type: object
           properties:
-            columnVisibility:
-              type: object
-              nullable: true
-              additionalProperties:
-                type: boolean
-            columnOrder:
-              type: array
-              nullable: true
-              items:
-                type: string
-            columnSizing:
-              type: object
-              nullable: true
-              additionalProperties:
-                type: number
-            grouping:
-              type: string
-              nullable: true
-            rowHeight:
-              type: string
-              nullable: true
-            layout:
-              type: string
-              nullable: true
-          title: TableViewOptions
-        - type: object
-          properties:
             viewType:
               type: string
               enum:
@@ -5740,6 +5713,33 @@ components:
             - viewType
             - options
           title: MonitorViewOptions
+        - type: object
+          properties:
+            columnVisibility:
+              type: object
+              nullable: true
+              additionalProperties:
+                type: boolean
+            columnOrder:
+              type: array
+              nullable: true
+              items:
+                type: string
+            columnSizing:
+              type: object
+              nullable: true
+              additionalProperties:
+                type: number
+            grouping:
+              type: string
+              nullable: true
+            rowHeight:
+              type: string
+              nullable: true
+            layout:
+              type: string
+              nullable: true
+          title: TableViewOptions
         - type: "null"
       description: Options for the view in the app
     View:


### PR DESCRIPTION
Update the spec so we can save views for the monitor page. 

My one issue here is that the description for this is: 

`"description": "Type of table that the view corresponds to." `

And the monitor page is graphs not tables. The database can handle this as it just stores a json blob that represents a "view" but I'm not sure if I should change anything else to make it clear that these views are more generic than what is here. 

