### PR TITLE
Revert "Update openapi spec to allow monitor-scopoed views (#153)"

### DIFF
--- a/openapi/spec.json
+++ b/openapi/spec.json
@@ -285,10 +285,9 @@
           "scorers",
           "logs",
           "agents",
-          "monitor",
           null
         ],
-        "description": "Type of object that the view corresponds to."
+        "description": "Type of table that the view corresponds to."
       },
       "UserGivenName": {
         "anyOf": [
@@ -6610,112 +6609,43 @@
         "description": "The view definition"
       },
       "ViewOptions": {
-        "anyOf": [
-          {
+        "type": "object",
+        "nullable": true,
+        "properties": {
+          "columnVisibility": {
             "type": "object",
-            "properties": {
-              "viewType": {
-                "type": "string",
-                "enum": [
-                  "monitor"
-                ]
-              },
-              "options": {
-                "type": "object",
-                "properties": {
-                  "spanType": {
-                    "type": "string",
-                    "nullable": true,
-                    "enum": [
-                      "range",
-                      "frame",
-                      null
-                    ]
-                  },
-                  "rangeValue": {
-                    "type": "string",
-                    "nullable": true
-                  },
-                  "frameStart": {
-                    "type": "string",
-                    "nullable": true
-                  },
-                  "frameEnd": {
-                    "type": "string",
-                    "nullable": true
-                  },
-                  "chartVisibility": {
-                    "type": "object",
-                    "nullable": true,
-                    "additionalProperties": {
-                      "type": "boolean"
-                    }
-                  },
-                  "projectId": {
-                    "type": "string",
-                    "nullable": true
-                  },
-                  "type": {
-                    "type": "string",
-                    "nullable": true,
-                    "enum": [
-                      "project",
-                      "experiment",
-                      null
-                    ]
-                  }
-                }
-              }
-            },
-            "required": [
-              "viewType",
-              "options"
-            ],
-            "title": "MonitorViewOptions"
+            "nullable": true,
+            "additionalProperties": {
+              "type": "boolean"
+            }
           },
-          {
+          "columnOrder": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "type": "string"
+            }
+          },
+          "columnSizing": {
             "type": "object",
-            "properties": {
-              "columnVisibility": {
-                "type": "object",
-                "nullable": true,
-                "additionalProperties": {
-                  "type": "boolean"
-                }
-              },
-              "columnOrder": {
-                "type": "array",
-                "nullable": true,
-                "items": {
-                  "type": "string"
-                }
-              },
-              "columnSizing": {
-                "type": "object",
-                "nullable": true,
-                "additionalProperties": {
-                  "type": "number"
-                }
-              },
-              "grouping": {
-                "type": "string",
-                "nullable": true
-              },
-              "rowHeight": {
-                "type": "string",
-                "nullable": true
-              },
-              "layout": {
-                "type": "string",
-                "nullable": true
-              }
-            },
-            "title": "TableViewOptions"
+            "nullable": true,
+            "additionalProperties": {
+              "type": "number"
+            }
           },
-          {
-            "type": "null"
+          "grouping": {
+            "type": "string",
+            "nullable": true
+          },
+          "rowHeight": {
+            "type": "string",
+            "nullable": true
+          },
+          "layout": {
+            "type": "string",
+            "nullable": true
           }
-        ],
+        },
         "description": "Options for the view in the app"
       },
       "View": {
@@ -6749,10 +6679,9 @@
               "scorers",
               "logs",
               "agents",
-              "monitor",
               null
             ],
-            "description": "Type of object that the view corresponds to."
+            "description": "Type of table that the view corresponds to."
           },
           "name": {
             "type": "string",
@@ -6817,10 +6746,9 @@
               "scorers",
               "logs",
               "agents",
-              "monitor",
               null
             ],
-            "description": "Type of object that the view corresponds to."
+            "description": "Type of table that the view corresponds to."
           },
           "name": {
             "type": "string",
@@ -6879,10 +6807,9 @@
               "scorers",
               "logs",
               "agents",
-              "monitor",
               null
             ],
-            "description": "Type of object that the view corresponds to."
+            "description": "Type of table that the view corresponds to."
           },
           "name": {
             "type": "string",
@@ -8571,7 +8498,7 @@
           "$ref": "#/components/schemas/ViewType"
         },
         "required": false,
-        "description": "Type of object that the view corresponds to.",
+        "description": "Type of table that the view corresponds to.",
         "name": "view_type",
         "in": "query"
       },

--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -301,9 +301,8 @@ components:
         - scorers
         - logs
         - agents
-        - monitor
         - null
-      description: Type of object that the view corresponds to.
+      description: Type of table that the view corresponds to.
     UserGivenName:
       anyOf:
         - type: string
@@ -5668,79 +5667,33 @@ components:
           $ref: "#/components/schemas/ViewDataSearch"
       description: The view definition
     ViewOptions:
-      anyOf:
-        - type: object
-          properties:
-            viewType:
-              type: string
-              enum:
-                - monitor
-            options:
-              type: object
-              properties:
-                spanType:
-                  type: string
-                  nullable: true
-                  enum:
-                    - range
-                    - frame
-                    - null
-                rangeValue:
-                  type: string
-                  nullable: true
-                frameStart:
-                  type: string
-                  nullable: true
-                frameEnd:
-                  type: string
-                  nullable: true
-                chartVisibility:
-                  type: object
-                  nullable: true
-                  additionalProperties:
-                    type: boolean
-                projectId:
-                  type: string
-                  nullable: true
-                type:
-                  type: string
-                  nullable: true
-                  enum:
-                    - project
-                    - experiment
-                    - null
-          required:
-            - viewType
-            - options
-          title: MonitorViewOptions
-        - type: object
-          properties:
-            columnVisibility:
-              type: object
-              nullable: true
-              additionalProperties:
-                type: boolean
-            columnOrder:
-              type: array
-              nullable: true
-              items:
-                type: string
-            columnSizing:
-              type: object
-              nullable: true
-              additionalProperties:
-                type: number
-            grouping:
-              type: string
-              nullable: true
-            rowHeight:
-              type: string
-              nullable: true
-            layout:
-              type: string
-              nullable: true
-          title: TableViewOptions
-        - type: "null"
+      type: object
+      nullable: true
+      properties:
+        columnVisibility:
+          type: object
+          nullable: true
+          additionalProperties:
+            type: boolean
+        columnOrder:
+          type: array
+          nullable: true
+          items:
+            type: string
+        columnSizing:
+          type: object
+          nullable: true
+          additionalProperties:
+            type: number
+        grouping:
+          type: string
+          nullable: true
+        rowHeight:
+          type: string
+          nullable: true
+        layout:
+          type: string
+          nullable: true
       description: Options for the view in the app
     View:
       type: object
@@ -5770,9 +5723,8 @@ components:
             - scorers
             - logs
             - agents
-            - monitor
             - null
-          description: Type of object that the view corresponds to.
+          description: Type of table that the view corresponds to.
         name:
           type: string
           description: Name of the view
@@ -5825,9 +5777,8 @@ components:
             - scorers
             - logs
             - agents
-            - monitor
             - null
-          description: Type of object that the view corresponds to.
+          description: Type of table that the view corresponds to.
         name:
           type: string
           description: Name of the view
@@ -5875,9 +5826,8 @@ components:
             - scorers
             - logs
             - agents
-            - monitor
             - null
-          description: Type of object that the view corresponds to.
+          description: Type of table that the view corresponds to.
         name:
           type: string
           nullable: true
@@ -7238,7 +7188,7 @@ components:
       schema:
         $ref: "#/components/schemas/ViewType"
       required: false
-      description: Type of object that the view corresponds to.
+      description: Type of table that the view corresponds to.
       name: view_type
       in: query
     UserGivenName:


### PR DESCRIPTION
I broke things: https://github.com/braintrustdata/braintrust/pull/5940

This reverts commit bbe95b09276a1805db576dc6723ebc8e5e6b192d.